### PR TITLE
Add flat out format

### DIFF
--- a/scripts/ArcGet.py
+++ b/scripts/ArcGet.py
@@ -103,7 +103,7 @@ def main():
                 logger.info('downloading scans %s', ','.join(scan_ids))
                 sess.download(args.label, scan_ids, project=args.project,
                               out_dir=args.output_dir, progress=1024**2,
-                              attempts=3)
+                              attempts=3, out_format=args.output_format)
 
 def generate_bids_config(scans):
     config = col.defaultdict(lambda: col.defaultdict(list))
@@ -193,7 +193,7 @@ def parse_args():
         help='Turn off SSL certificate checking (needed for tunneled connections)')
     parser.add_argument('-o', '--output-dir', '--out-dir', default='.',
         help='Output directory')
-    parser.add_argument('-f', '--output-format', choices=['1.4', 'bids', 'flat'], default='1.4',
+    parser.add_argument('-f', '--output-format', choices=['1.4', 'bids', 'flat', 'native'], default='1.4',
         help='Output directory format')
     parser.add_argument('--bids', action='store_true',
         help='Output in BIDS format (same as --output-format=bids)')

--- a/scripts/ArcGet.py
+++ b/scripts/ArcGet.py
@@ -151,7 +151,7 @@ def find(scans_mdata, targets, key):
 
 def splitarg(args):
     '''
-    This function will split arguments separated by spaces or commas 
+    This function will split arguments separated by spaces or commas
     to be backwards compatible with the original ArcGet command line tool
     '''
     if not args:
@@ -181,7 +181,7 @@ def parse_args():
     group_c = parser.add_mutually_exclusive_group()
     group_c.add_argument('--scans', nargs='+',
         help='Raw scans numbers')
-    group_c.add_argument('-r', '--raw-types', nargs='+', 
+    group_c.add_argument('-r', '--raw-types', nargs='+',
         help='Same as --scans (deprecated)')
     parser.add_argument('-c', '--config',
         help='BIDS configuration')
@@ -203,4 +203,3 @@ def parse_args():
 
 if __name__ == '__main__':
     main()
-

--- a/yaxil/__init__.py
+++ b/yaxil/__init__.py
@@ -33,7 +33,7 @@ logging.getLogger("requests").setLevel(logging.WARNING)
 
 class Format(object):
     '''
-    A container to hold possible XNAT response formats: Format.JSON, 
+    A container to hold possible XNAT response formats: Format.JSON,
     Format.XML, and Format.CSV.
     '''
     JSON  = "json"
@@ -46,14 +46,14 @@ XnatAuth = col.namedtuple("XnatAuth", [
     "password"
 ])
 '''
-Container to hold XNAT authentication information. Fields include the ``url``, 
+Container to hold XNAT authentication information. Fields include the ``url``,
 ``username``, and ``password``.
 '''
 
 @contextmanager
 def session(auth):
     '''
-    Create a session context to avoid explicitly passing authentication to 
+    Create a session context to avoid explicitly passing authentication to
     every function.
 
     Example:
@@ -134,7 +134,7 @@ def auth(alias=None, url=None, cfg="~/.xnat_auth"):
         raise AuthError("no password for %s in %s" % (alias, cfg))
     elif len(password) > 1:
         raise AuthError("too many passwords for %s in %s" % (alias, cfg))
-    return XnatAuth(url=url.pop().text, username=username.pop().text, 
+    return XnatAuth(url=url.pop().text, username=username.pop().text,
                         password=password.pop().text)
 
 Subject = col.namedtuple('Subject', [
@@ -144,19 +144,19 @@ Subject = col.namedtuple('Subject', [
     'project'
 ])
 '''
-Container to hold XNAT Subject information. Fields include the Subject URI 
+Container to hold XNAT Subject information. Fields include the Subject URI
 (``uri``), Accession ID (``id``), Project (``project``), and Label (``label``).
 '''
 
 def subjects(auth, label=None, project=None):
     '''
     Retrieve Subject tuples for subjects returned by this function.
-    
+
     Example:
         >>> import yaxil
         >>> auth = yaxil.XnatAuth(url='...', username='...', password='...')
         >>> yaxil.subjects(auth, 'AB1234C')
-        Subject(uri=u'/data/experiments/XNAT_S0001', label=u'AB1234C', id=u'XNAT_S0001', 
+        Subject(uri=u'/data/experiments/XNAT_S0001', label=u'AB1234C', id=u'XNAT_S0001',
             project=u'MyProject')
 
     :param auth: XNAT authentication
@@ -184,7 +184,7 @@ def subjects(auth, label=None, project=None):
     if project:
         payload['project'] = project
     # submit the request
-    r = requests.get(url, params=payload, auth=(auth.username, auth.password), 
+    r = requests.get(url, params=payload, auth=(auth.username, auth.password),
                      verify=CHECK_CERTIFICATE)
     # validate response
     if r.status_code != requests.codes.ok:
@@ -214,21 +214,21 @@ Experiment = col.namedtuple('Experiment', [
     'archived_date'
 ])
 '''
-Container to hold XNAT Experiment information. Fields include the Experiment URI 
-(``uri``), Accession ID (``id``), Project (``project``), Label (``label``), 
-Subject Accession ID (``subject_id``), Subject label (``subject_label``), and 
+Container to hold XNAT Experiment information. Fields include the Experiment URI
+(``uri``), Accession ID (``id``), Project (``project``), Label (``label``),
+Subject Accession ID (``subject_id``), Subject label (``subject_label``), and
 archived date (``archived_date``).
 '''
 
 def experiments(auth, label=None, project=None, subject=None):
     '''
     Retrieve Experiment tuples for experiments returned by this function.
-    
+
     Example:
         >>> import yaxil
         >>> auth = yaxil.XnatAuth(url='...', username='...', password='...')
         >>> yaxil.experiment(auth, 'AB1234C')
-        Experiment(uri=u'/data/experiments/XNAT_E0001', label=u'AB1234C', id=u'XNAT_E0001', 
+        Experiment(uri=u'/data/experiments/XNAT_E0001', label=u'AB1234C', id=u'XNAT_E0001',
             project=u'MyProject', subject_id=u'XNAT_S0001', subject_label='ABC')
 
     :param auth: XNAT authentication
@@ -266,7 +266,7 @@ def experiments(auth, label=None, project=None, subject=None):
         payload['project'] = subject.project
         payload['xnat:subjectassessordata/subject_id'] = subject.id
     # submit request
-    r = requests.get(url, params=payload, auth=(auth.username, auth.password), 
+    r = requests.get(url, params=payload, auth=(auth.username, auth.password),
                      verify=CHECK_CERTIFICATE)
     # validate response
     if r.status_code != requests.codes.ok:
@@ -280,12 +280,12 @@ def experiments(auth, label=None, project=None, subject=None):
     if int(results['totalRecords']) == 0:
         raise NoExperimentsError('no records returned for {0}'.format(r.url))
     for item in results['Result']:
-        yield Experiment(uri=item['URI'], 
-                         id=item['ID'], 
-                         project=item['project'], 
-                         label=item['label'], 
-                         subject_id=item['subject_ID'], 
-                         subject_label=item['subject_label'], 
+        yield Experiment(uri=item['URI'],
+                         id=item['ID'],
+                         project=item['project'],
+                         label=item['label'],
+                         subject_id=item['subject_ID'],
+                         subject_label=item['subject_label'],
                          archived_date=item['insert_date'])
 
 @functools.lru_cache
@@ -323,7 +323,7 @@ def download(auth, label, scan_ids=None, project=None, aid=None,
              out_dir='.', in_mem=True, progress=False, attempts=1):
     '''
     Download scan data from XNAT.
-    
+
     Example:
         >>> import yaxil
         >>> auth = yaxil.XnatAuth(url='...', username='...', password='...')
@@ -347,24 +347,24 @@ def download(auth, label, scan_ids=None, project=None, aid=None,
     :type progress: int
     :param attempts: Number of download attempts
     :type attempts: int
-    ''' 
+    '''
     if not scan_ids:
         scan_ids = ['ALL']
     if not aid:
         aid = accession(auth, label, project)
     # build the url
-    url = "%s/data/experiments/%s/scans/%s/files?format=zip" % (auth.url.rstrip('/'), 
+    url = "%s/data/experiments/%s/scans/%s/files?format=zip" % (auth.url.rstrip('/'),
             aid, ','.join([str(x) for x in scan_ids]))
     # issue the http request, with exponential backoff retry behavior
     backoff = 10
-    for _ in range(attempts): 
+    for _ in range(attempts):
         logger.debug("issuing http request %s", url)
         r = requests.get(url, stream=True, auth=(auth.username, auth.password), verify=CHECK_CERTIFICATE)
         logger.debug("response headers %s", r.headers)
         if r.status_code == requests.codes.ok:
             break
         fuzz = random.randint(0, 10)
-        logger.warn("download unsuccessful (%s), retrying in %s seconds", r.status_code, 
+        logger.warn("download unsuccessful (%s), retrying in %s seconds", r.status_code,
                     backoff + fuzz)
         time.sleep(backoff + fuzz)
         backoff *= 2
@@ -425,10 +425,10 @@ def extract(zf, content, out_dir='.'):
     for i,member in enumerate(zf.infolist()):
         '''
         Right... so when Java 1.6 produces a Zip filesystem that exceeds 2^32
-        bytes, the Central Directory local file header offsets after the 2^32 
-        byte appear to overflow. The Python zipfile module then adds any 
-        unexpected bytes to each header offset thereafter. This attempts to fix 
-        that. My guess is that this comment might make perfect sense now, but 
+        bytes, the Central Directory local file header offsets after the 2^32
+        byte appear to overflow. The Python zipfile module then adds any
+        unexpected bytes to each header offset thereafter. This attempts to fix
+        that. My guess is that this comment might make perfect sense now, but
         will make aboslutely no sense in about a year.
         '''
         # undo concat padding added from zipfile.py:819
@@ -739,7 +739,7 @@ extendedboldqc.columns = {
 def _get(auth, path, fmt, autobox=True, params=None):
     '''
     Issue a GET request to the XNAT REST API and box the response content.
-    
+
     Example:
         >>> import yaxil
         >>> from yaxil import Format
@@ -842,4 +842,3 @@ def has(auth, xsitype, project=None):
     if int(result["ResultSet"]["totalRecords"]) == 0:
         return False
     return True
-

--- a/yaxil/__init__.py
+++ b/yaxil/__init__.py
@@ -320,7 +320,8 @@ Container to hold download options. Not in use yet.
 '''
 
 def download(auth, label, scan_ids=None, project=None, aid=None,
-             out_dir='.', in_mem=True, progress=False, attempts=1):
+             out_dir='.', in_mem=True, progress=False, attempts=1,
+             out_format='flat'):
     '''
     Download scan data from XNAT.
 
@@ -341,6 +342,8 @@ def download(auth, label, scan_ids=None, project=None, aid=None,
     :type aid: str
     :param out_dir: Output directory
     :type out_dir: str
+    :param out_format: Extract all files or leave native structure
+    :type output_format: str
     :param in_mem: Keep download content in memory; faster but uses more memory
     :type in_mem: bool
     :param progress: Show download progress every N bytes
@@ -409,7 +412,12 @@ def download(auth, label, scan_ids=None, project=None, aid=None,
         raise DownloadError("bad zip file, written to %s" % fo.name)
     # finally extract the zipfile (with various nasty edge cases handled)
     logger.debug("extracting zip archive to %s", out_dir)
-    extract(zf, content, out_dir)
+
+    if out_format == 'native':
+        zf.extractall(path=out_dir)
+    else:  # out_format == 'flat' or out_format == '1.4'
+        extract(zf, content, out_dir)
+
 
 def extract(zf, content, out_dir='.'):
     '''


### PR DESCRIPTION
Use `zipfile.extractall()` to maintain directory structure inside the zipfile when extracting (necessary for identically named files in different directories).