### PR TITLE
add dcm2niix as an external dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ requires = [
     'pyaml',
     'lxml',
     'six',
-    'jsonpath-ng'
+    'jsonpath-ng',
+    'dcm2niix'
 ]
 
 test_requirements = [


### PR DESCRIPTION
dcm2niix is used in the "bidsify-ing" feature of ArcGet.py. This is a small pull request to make dcm2niix an official dependency.