### PR TITLE
removing explicit request for URI property

### DIFF
--- a/yaxil/__init__.py
+++ b/yaxil/__init__.py
@@ -981,7 +981,6 @@ def __get_xsi_types(auth, aid):
 def __experiment_details(auth, aid):
   path = f'/data/experiments'
   columns = [
-    'URI',
     'xsiType',
     'ID',
     'label',


### PR DESCRIPTION
Small bug fix. The XNAT REST endpoint "/data/experiments" automatically returns the property "URI". Explicitly requesting this property leads to an error on the server side XNAT "restlet.log" -- at least for XNAT versions 1.7.6 and 1.8.10.5.